### PR TITLE
Change distribution method of the module

### DIFF
--- a/HorribleDownloader/cmd.py
+++ b/HorribleDownloader/cmd.py
@@ -150,8 +150,7 @@ def main(args):
             with open(os.path.join(CONFIG.dir, CONFIG.file), "w") as f:
                 CONFIG.conf.write(f)
 
-
-if __name__ == "__main__":
+def cli():
     parser = argparse.ArgumentParser(description='horrible script for downloading anime')
     parser.add_argument('-d', '--download', help="download a specific anime", type=str)
     parser.add_argument('-o', '--output', help="directory to which it will download the files", type=str)
@@ -186,3 +185,7 @@ if __name__ == "__main__":
         exit(0)
 
     main(args)
+
+
+if __name__ == "__main__":
+    cli()

--- a/README.md
+++ b/README.md
@@ -8,20 +8,10 @@
 
 ## Installation
 
-##### Linux:
-```sh
-$ git clone https://github.com/jelomite/horrible-downloader.git
-$ cd horrible-downloader
-$ pip install .
-```
-
-##### Windows:
 ```sh
 > git clone https://github.com/jelomite/horrible-downloader.git
 > cd horrible-downloader
 > pip install .
-> set PathExt="%PathExt%;.PY" # add PY extension to PATHEXT
-> npm install webtorrent-cli -g
 ```
 
 ## Dependencies

--- a/bin/horrible-downloader
+++ b/bin/horrible-downloader
@@ -72,7 +72,7 @@ def download(episode, qualities, path):
     """
     subdir = os.path.join(path, episode["title"].title())
     for quality in qualities:
-        subprocess.call(["webtorrent", episode[quality]["Magnet"], "-o", subdir], shell=True)
+        subprocess.call(["webtorrent",  "-o", subdir, "download", episode[quality]["Magnet"]], shell=True)
 
 def main(args):
     clear()

--- a/post_install.sh
+++ b/post_install.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-if $(npm list -g | grep -q "webtorrent"); then
-	echo "webtorrent found... SKIPPING install"
-else
-	
-	npm install webtorrent-cli -g
-fi

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,21 @@ import subprocess
 with open("README.md", 'r') as f:
     long_description = f.read()
 
+class custom_install(install):
+    def run(self):
+        # check if webtorrent is installed
+        try:
+            webtorrent_version = subprocess.check_output(["webtorrent", "-v"], shell=True)
+
+        except subprocess.CalledProcessError:
+            try:
+                subprocess.call(["npm", "install", "webtorrent-cli", "-g"], shell=True)
+            except subprocess.CalledProcessError:
+                pass
+
+        finally:
+            install.run(self)
+
 setup(
     name='Horrible-Downloader',
     version='0.1.6',

--- a/setup.py
+++ b/setup.py
@@ -6,21 +6,6 @@ import subprocess
 with open("README.md", 'r') as f:
     long_description = f.read()
 
-class custom_install(install):
-    def run(self):
-        install.run(self)
-        if os.name == "nt":
-            #TODO: call post install for windows
-            pass
-        else:
-            subprocess.call(["./post_install.sh"])
-
-if os.name == "nt":
-    try:
-        os.rename(os.path.abspath("bin/horrible-downloader"), os.path.abspath("bin/horrible-downloader.py"))
-    except FileNotFoundError:
-        pass
-
 setup(
     name='Horrible-Downloader',
     version='0.1.6',
@@ -40,7 +25,9 @@ setup(
         'fuzzywuzzy>=0.16',
         'python-levenshtein>=0.12'
     ],
-    scripts=["bin/horrible-downloader.py"] if os.name == "nt" else ["bin/horrible-downloader"],
+    entry_points={
+        "console_scripts": ["horrible-downloader=HorribleDownloader.cmd:cli"]
+    },
     include_package_data=True,
     zip_safe=False,
     classifiers=(

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 from setuptools import setup
 from setuptools.command.install import install
 import subprocess
@@ -10,8 +9,7 @@ class custom_install(install):
     def run(self):
         # check if webtorrent is installed
         try:
-            webtorrent_version = subprocess.check_output(["webtorrent", "-v"], shell=True)
-
+            subprocess.call(["webtorrent", "-v"], shell=True)
         except subprocess.CalledProcessError:
             try:
                 subprocess.call(["npm", "install", "webtorrent-cli", "-g"], shell=True)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ class custom_install(install):
 
 setup(
     name='Horrible-Downloader',
-    version='0.1.6',
+    version='0.1.7',
     packages=['HorribleDownloader'],
     url='https://github.com/Jelomite/horrible-downloader',
     license='MIT',


### PR DESCRIPTION
The old method of distribution was inconsistent with different platforms.
I've now changed it to use the standard "console_scripts" way. This simplifies a lot of the installation process on windows machines. 

This should solve issue #8 once and for all. 