### PR TITLE
Add no confirm flag

### DIFF
--- a/HorribleDownloader/cmd.py
+++ b/HorribleDownloader/cmd.py
@@ -247,10 +247,13 @@ def main(args):
         else:
             print(fg(1) + 'No new episodes were found. Exiting ' + fg.rs)
         exit(1) # arguably should be exit code 0
+    if args.noconfirm:
+        inp = ""
+    else:
+        # summerizing info about the download
+        reprint_results(downloads, QUALITIES)
+        inp = input(f'{fg(3)}\nwould you like to re-arrange the downloads? (Return for default) {fg.rs}')
 
-    # summerizing info about the download
-    reprint_results(downloads, QUALITIES)
-    inp = input(f'{fg(3)}\nwould you like to re-arrange the downloads? (Return for default) {fg.rs}')
     if inp is "": # continue as usually.
         pass
 
@@ -336,6 +339,7 @@ def cli():
         parser.add_argument('--batch', help="search for batches as well as regular files", action="store_true")
         parser.add_argument('-q', '--quiet', help="set quiet mode on", action="store_true")
         parser.add_argument('-lc', '--list-current', help="list all currently airing shows", action="store_true")
+        parser.add_argument('--noconfirm', help="Bypass any and all “Are you sure?” messages.", action="store_true")
         args = parser.parse_args()
 
         if args.subscribe:

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ optional arguments:
   -r RESOLUTION, --resolution RESOLUTION     specify resolution quality, defaults to config file
   --subscribe SHOW [-e EPISODE]              add a show to the config file.
   --batch                                    search for batches as well as regular files
-
+  --noconfirm                                bypass any and all “Are you sure?” messages.
 ```
 ##### Episodes & Resolution Formating:
 Those two flags have a special syntax which allows for a better specification interface.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ class custom_install(install):
 
 setup(
     name='horrible-downloader',
-    version='1.0.3',
+    version='1.0.4',
     packages=['HorribleDownloader'],
     url='https://github.com/Jelomite/horrible-downloader',
     license='MIT',


### PR DESCRIPTION
When using a script to automate and schedule downloads, it's really convenient to have a `--noconfirm` flag. This flag, when used, will bypass the confirmation messages. 