### PR TITLE
Improve title search

### DIFF
--- a/HorribleDownloader/parser.py
+++ b/HorribleDownloader/parser.py
@@ -18,7 +18,9 @@ class Parser:
         # because we're dealing with html, there will be character references.
         # there might be other references other than the ampersand.
         title = title.replace("&amp;", "&")
-        proper_title, ratio = process.extractOne(title, self.shows.keys(), scorer=fuzz.token_set_ratio)
+        possible_titles = process.extract(title, self.shows.keys(), scorer=fuzz.token_set_ratio, limit=20) # select 20 best titles based on token_set_ratio
+        only_best_matching_titles = [p[0] for p in possible_titles if p[1] >= possible_titles[0][1]]  # selects only titles with token_set_ratio equal to best found ratio
+        proper_title, ratio = process.extractOne(title, only_best_matching_titles, scorer=fuzz.token_sort_ratio) # selects title with best token_sort_ratio from previous selection
         # if the proper_title is too different than the title, return "".
         if ratio <= min_threshold:
             return ""


### PR DESCRIPTION
Fixes #56 without losing the benefits of changes made for #52 .

By using first the fuzz.token_set_ratio to select titles we keep the same intended behavior as mentioned in #52 .
However, by posteriorly using fuzz.token_sort_ratio we can further restrict the results, making the intended behavior mentioned in #56 also possible. 

examples previous to changes: 
"enen s2" -> "Enen no Shouboutai S2"
"boku no hero academia - ikinokore! kesshi no survival kunren" -> "Boku no Hero Academia"
"one punch" -> "One Punch Man S2"

examples after changes: 
"enen s2" -> "Enen no Shouboutai S2"
"boku no hero academia - ikinokore! kesshi no survival kunren" -> "Boku no Hero Academia - Ikinokore! Kesshi no Survival Kunren"
"one punch" -> "One-Punch Man"